### PR TITLE
Support Multiple Header Keys & Throw meaningful exceptions on ApiKey header Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ private async Task<IEnumerable<Claim>> GenerateClaims(ApiKeyGenerateClaimsContex
     return new[] { new Claim(ClaimTypes.Name, "Fred") };
 }
 ```
+
+##Changes in Fork
+
+Add HeaderKey Array.
+This allows developers to support ApiKeys of the format "Apikey 123" and "1234".
+This is useful when creating custom connectors for Microsoft flow or Zapier.
+
+Meaningful Exceptions on Errors
+Developers can catch the exception in a custom ExceptionHandlerMiddleware and provide meaning feedback to users. Currently 401 response with '"Message": "Authorization has been denied for this request."' is provided for an invalid request which doesn't give enough insight to the issue.
+
+Add Unit Tests for the changes
+Existing users get errors instead of 401 response
+

--- a/src/Microsoft.Owin.Security.ApiKey.Tests/AuthenticationTests.cs
+++ b/src/Microsoft.Owin.Security.ApiKey.Tests/AuthenticationTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Owin.Security.ApiKey.Tests
 
         }
 
-        [TestMethod]
+       [TestMethod]
         public async Task WebRequest_Wrong_HeaderKey_Should_Yield_InvalidCredentialsException()
         {
             try

--- a/src/Microsoft.Owin.Security.ApiKey.Tests/AuthenticationTests.cs
+++ b/src/Microsoft.Owin.Security.ApiKey.Tests/AuthenticationTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
+using System.Security.Authentication;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Owin.Security.ApiKey.Web;
@@ -25,12 +27,61 @@ namespace Microsoft.Owin.Security.ApiKey.Tests
         }
 
         [TestMethod]
-        public async Task WebRequest_Anonymous_Authentication_Should_Yield_401()
+        public async Task WebRequest_No_Authorization_Header_Should_Yield_ArgumentNullException()
         {
-            var response = await this.api.HttpClient.GetAsync("/api/values");
+            try
+            {
+                await this.api.HttpClient.GetAsync("/api/values");
+            }
+            catch (Exception e)
+            {
+                e.Should().BeOfType<ArgumentNullException>();
+            }
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         }
+
+        [TestMethod]
+        public async Task WebRequest_No_HeaderKey_Should_Yield_ArgumentNullException()
+        {
+            try
+            {
+                await this.api.CreateRequest("/api/values").AddHeader("Authorization", null).GetAsync(); ;
+            }
+            catch (Exception e)
+            {
+                e.Should().BeOfType<ArgumentNullException>();
+            }
+
+        }
+
+        [TestMethod]
+        public async Task WebRequest_Wrong_HeaderKey_Should_Yield_InvalidCredentialsException()
+        {
+            try
+            {
+                await this.api.CreateRequest("/api/values").AddHeader("Authorization", "Bearer 1234").GetAsync(); ;
+            }
+            catch (Exception e)
+            {
+                e.Should().BeOfType<InvalidCredentialException>();
+            }
+
+        }
+
+        [TestMethod]
+        public async Task WebRequest_Empty_HeaderKey_Should_Yield_ArgumentNullException()
+        {
+            try
+            {
+                await this.api.CreateRequest("/api/values").AddHeader("Authorization", "").GetAsync(); ;
+            }
+            catch (Exception e)
+            {
+                e.Should().BeOfType<ArgumentNullException>();
+            }
+
+        }
+
 
         [TestMethod]
         public async Task WebRequest_ApiKey_Authentication_Should_Yield_200()

--- a/src/Microsoft.Owin.Security.ApiKey.Tests/AuthenticationTests.cs
+++ b/src/Microsoft.Owin.Security.ApiKey.Tests/AuthenticationTests.cs
@@ -35,8 +35,10 @@ namespace Microsoft.Owin.Security.ApiKey.Tests
         [TestMethod]
         public async Task WebRequest_ApiKey_Authentication_Should_Yield_200()
         {
-            var response = await this.api.CreateRequest("/api/values").AddHeader("Authorization", "ApiKey 123").GetAsync();
-
+            var response = await this.api.CreateRequest("/api/values").AddHeader("Authorization", "ApiKey 123")
+                .GetAsync();
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response = await this.api.CreateRequest("/api/values").AddHeader("Authorization", "123").GetAsync();
             response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
     }

--- a/src/Microsoft.Owin.Security.ApiKey.Tests/Microsoft.Owin.Security.ApiKey.Tests.csproj
+++ b/src/Microsoft.Owin.Security.ApiKey.Tests/Microsoft.Owin.Security.ApiKey.Tests.csproj
@@ -35,13 +35,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.18.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.18.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions.Core, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -55,9 +53,8 @@
       <HintPath>..\packages\Microsoft.Owin.Testing.3.0.1\lib\net45\Microsoft.Owin.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/src/Microsoft.Owin.Security.ApiKey.Tests/app.config
+++ b/src/Microsoft.Owin.Security.ApiKey.Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/Microsoft.Owin.Security.ApiKey.Tests/packages.config
+++ b/src/Microsoft.Owin.Security.ApiKey.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.18.0" targetFramework="net461" />
+  <package id="FluentAssertions" version="4.19.4" targetFramework="net461" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net461" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net461" />
   <package id="Microsoft.Owin.Testing" version="3.0.1" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
 </packages>

--- a/src/Microsoft.Owin.Security.ApiKey.Web/App_Start/Startup.cs
+++ b/src/Microsoft.Owin.Security.ApiKey.Web/App_Start/Startup.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Owin.Security.ApiKey.Web
                 {
                     OnValidateIdentity = this.ValidateApiKey,
                     OnGenerateClaims = this.GenerateClaims
-                }
+                },
+                HeaderKey = new []{"Apikey" , "apiKey", "APIKEY",""}
             });
 
             var config = new HttpConfiguration();

--- a/src/Microsoft.Owin.Security.ApiKey.Web/App_Start/Startup.cs
+++ b/src/Microsoft.Owin.Security.ApiKey.Web/App_Start/Startup.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Owin.Security.ApiKey.Web
                     OnValidateIdentity = this.ValidateApiKey,
                     OnGenerateClaims = this.GenerateClaims
                 },
-                HeaderKey = new []{"Apikey" ,""}
+                HeaderKeyArray = new []{"Apikey" ,""}
             });
 
             var config = new HttpConfiguration();

--- a/src/Microsoft.Owin.Security.ApiKey.Web/App_Start/Startup.cs
+++ b/src/Microsoft.Owin.Security.ApiKey.Web/App_Start/Startup.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Owin.Security.ApiKey.Web
                     OnValidateIdentity = this.ValidateApiKey,
                     OnGenerateClaims = this.GenerateClaims
                 },
-                HeaderKey = new []{"Apikey" , "apiKey", "APIKEY",""}
+                HeaderKey = new []{"Apikey" ,""}
             });
 
             var config = new HttpConfiguration();

--- a/src/Microsoft.Owin.Security.ApiKey.Web/App_Start/SwaggerConfig.cs
+++ b/src/Microsoft.Owin.Security.ApiKey.Web/App_Start/SwaggerConfig.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Owin.Security.ApiKey.Web
         {
             var thisAssembly = typeof(SwaggerConfig).Assembly;
 
-            GlobalConfiguration.Configuration 
+            GlobalConfiguration.Configuration
                 .EnableSwagger(c =>
                     {
                         // By default, the service root url is inferred from the request used to access the docs.
@@ -33,6 +33,10 @@ namespace Microsoft.Owin.Security.ApiKey.Web
                         // additional fields by chaining methods off SingleApiVersion.
                         //
                         c.SingleApiVersion("v1", "Microsoft.Owin.Security.ApiKey.Web");
+
+                        // If you want the output Swagger docs to be indented properly, enable the "PrettyPrint" option.
+                        //
+                        //c.PrettyPrint();
 
                         // If your API has multiple versions, use "MultipleApiVersions" instead of "SingleApiVersion".
                         // In this case, you must provide a lambda that tells Swashbuckle which actions should be
@@ -127,18 +131,18 @@ namespace Microsoft.Owin.Security.ApiKey.Web
 
                         // Alternatively, you can provide your own custom strategy for inferring SchemaId's for
                         // describing "complex" types in your API.
-                        //  
+                        //
                         //c.SchemaId(t => t.FullName.Contains('`') ? t.FullName.Substring(0, t.FullName.IndexOf('`')) : t.FullName);
 
                         // Set this flag to omit schema property descriptions for any type properties decorated with the
-                        // Obsolete attribute 
+                        // Obsolete attribute
                         //c.IgnoreObsoleteProperties();
 
                         // In accordance with the built in JsonSerializer, Swashbuckle will, by default, describe enums as integers.
                         // You can change the serializer behavior by configuring the StringToEnumConverter globally or for a given
                         // enum type. Swashbuckle will honor this change out-of-the-box. However, if you use a different
                         // approach to serialize enums as strings, you can also force Swashbuckle to describe them as strings.
-                        // 
+                        //
                         //c.DescribeAllEnumsAsStrings();
 
                         // Similar to Schema filters, Swashbuckle also supports Operation and Document filters:
@@ -164,7 +168,7 @@ namespace Microsoft.Owin.Security.ApiKey.Web
                         // In contrast to WebApi, Swagger 2.0 does not include the query string component when mapping a URL
                         // to an action. As a result, Swashbuckle will raise an exception if it encounters multiple actions
                         // with the same path (sans query string) and HTTP method. You can workaround this by providing a
-                        // custom strategy to pick a winner or merge the descriptions for the purposes of the Swagger docs 
+                        // custom strategy to pick a winner or merge the descriptions for the purposes of the Swagger docs
                         //
                         //c.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
 
@@ -175,6 +179,11 @@ namespace Microsoft.Owin.Security.ApiKey.Web
                     })
                 .EnableSwaggerUi(c =>
                     {
+                        // Use the "DocumentTitle" option to change the Document title.
+                        // Very helpful when you have multiple Swagger pages open, to tell them apart.
+                        //
+                        //c.DocumentTitle("My Swagger UI");
+
                         // Use the "InjectStylesheet" option to enrich the UI with one or more additional CSS stylesheets.
                         // The file must be included in your project as an "Embedded Resource", and then the resource's
                         // "Logical Name" is passed to the method as shown below.
@@ -237,7 +246,7 @@ namespace Microsoft.Owin.Security.ApiKey.Web
                         //);
 
                         // If your API supports ApiKey, you can override the default values.
-                        // "apiKeyIn" can either be "query" or "header"                                                
+                        // "apiKeyIn" can either be "query" or "header"
                         //
                         //c.EnableApiKeySupport("apiKey", "header");
                     });

--- a/src/Microsoft.Owin.Security.ApiKey.Web/Microsoft.Owin.Security.ApiKey.Web.csproj
+++ b/src/Microsoft.Owin.Security.ApiKey.Web/Microsoft.Owin.Security.ApiKey.Web.csproj
@@ -19,6 +19,7 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,13 +40,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Logging.1.1.0\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=1.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.1.1.4\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.1.0\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.1.4\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -71,21 +70,18 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Swashbuckle.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cd1bb07a5ac7c7bc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Swashbuckle.Core.5.5.3\lib\net40\Swashbuckle.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Swashbuckle.Core.5.6.0\lib\net40\Swashbuckle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.1.0\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.1.4\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web.DynamicData" />

--- a/src/Microsoft.Owin.Security.ApiKey.Web/Web.config
+++ b/src/Microsoft.Owin.Security.ApiKey.Web/Web.config
@@ -22,7 +22,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/Microsoft.Owin.Security.ApiKey.Web/packages.config
+++ b/src/Microsoft.Owin.Security.ApiKey.Web/packages.config
@@ -6,18 +6,18 @@
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.IdentityModel.Logging" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.IdentityModel.Tokens" version="5.1.0" targetFramework="net452" />
+  <package id="Microsoft.IdentityModel.Logging" version="1.1.4" targetFramework="net452" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.1.4" targetFramework="net452" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
-  <package id="Swashbuckle" version="5.5.3" targetFramework="net452" />
-  <package id="Swashbuckle.Core" version="5.5.3" targetFramework="net452" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="5.1.0" targetFramework="net452" />
+  <package id="Swashbuckle" version="5.6.0" targetFramework="net452" />
+  <package id="Swashbuckle.Core" version="5.6.0" targetFramework="net452" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.1.4" targetFramework="net452" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net452" />
 </packages>

--- a/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationHandler.cs
@@ -15,10 +15,14 @@ namespace Microsoft.Owin.Security.ApiKey
 
             if (!String.IsNullOrWhiteSpace(authorizationHeader))
             {
-                if (Options.HeaderKey.Length > 0)
+                if (Options.HeaderKeyArray == null && Options.HeaderKey!=null)
+                {
+                    Options.HeaderKeyArray = new[] {Options.HeaderKey};
+                }
+                if (Options.HeaderKeyArray != null && Options.HeaderKeyArray.Length > 0)
                 {
                     var headerKeyFound = false;
-                    foreach (var headerKey in this.Options.HeaderKey)
+                    foreach (var headerKey in this.Options.HeaderKeyArray)
                     {
                         if (authorizationHeader.StartsWith(headerKey, StringComparison.OrdinalIgnoreCase))
                         {

--- a/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationHandler.cs
@@ -14,24 +14,29 @@ namespace Microsoft.Owin.Security.ApiKey
 
             if (!String.IsNullOrWhiteSpace(authorizationHeader))
             {
-                if (authorizationHeader.StartsWith(this.Options.HeaderKey, StringComparison.OrdinalIgnoreCase))
+                foreach (var headerKey in this.Options.HeaderKey)
                 {
-                    string apiKey = authorizationHeader.Substring(this.Options.HeaderKey.Length).Trim();
-
-                    var context = new ApiKeyValidateIdentityContext(this.Context, this.Options, apiKey);
-
-                    await this.Options.Provider.ValidateIdentity(context);
-
-                    if (context.IsValidated)
+                    if (authorizationHeader.StartsWith(headerKey, StringComparison.OrdinalIgnoreCase))
                     {
-                        var claims = await this.Options.Provider.GenerateClaims(new ApiKeyGenerateClaimsContext(this.Context, this.Options, apiKey));
+                        string apiKey = authorizationHeader.Substring(headerKey.Length).Trim();
 
-                        var identity = new ClaimsIdentity(claims, this.Options.AuthenticationType);
+                        var context = new ApiKeyValidateIdentityContext(this.Context, this.Options, apiKey);
 
-                        return new AuthenticationTicket(identity, new AuthenticationProperties()
+                        await this.Options.Provider.ValidateIdentity(context);
+
+                        if (context.IsValidated)
                         {
-                            IssuedUtc = DateTime.UtcNow
-                        });
+                            var claims =
+                                await this.Options.Provider.GenerateClaims(
+                                    new ApiKeyGenerateClaimsContext(this.Context, this.Options, apiKey));
+
+                            var identity = new ClaimsIdentity(claims, this.Options.AuthenticationType);
+
+                            return new AuthenticationTicket(identity, new AuthenticationProperties()
+                            {
+                                IssuedUtc = DateTime.UtcNow
+                            });
+                        }
                     }
                 }
             }

--- a/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationHandler.cs
@@ -11,64 +11,66 @@ namespace Microsoft.Owin.Security.ApiKey
     {
         protected override async Task<AuthenticationTicket> AuthenticateCoreAsync()
         {
-            string authorizationHeader = this.Request.Headers.Get(this.Options.Header);
-
-            if (!String.IsNullOrWhiteSpace(authorizationHeader))
+            if (this.Request.Headers.ContainsKey(this.Options.Header))
             {
-                if (Options.HeaderKeyArray == null && Options.HeaderKey!=null)
+                string authorizationHeader = this.Request.Headers.Get(this.Options.Header);
+
+                if (!string.IsNullOrWhiteSpace(authorizationHeader))
                 {
-                    Options.HeaderKeyArray = new[] {Options.HeaderKey};
-                }
-                if (Options.HeaderKeyArray != null && Options.HeaderKeyArray.Length > 0)
-                {
-                    var headerKeyFound = false;
-                    foreach (var headerKey in this.Options.HeaderKeyArray)
+                    if (Options.HeaderKeyArray == null && Options.HeaderKey != null)
                     {
-                        if (authorizationHeader.StartsWith(headerKey, StringComparison.OrdinalIgnoreCase))
+                        Options.HeaderKeyArray = new[] {Options.HeaderKey};
+                    }
+                    if (Options.HeaderKeyArray != null && Options.HeaderKeyArray.Length > 0)
+                    {
+                        var headerKeyFound = false;
+                        foreach (var headerKey in this.Options.HeaderKeyArray)
                         {
-                            headerKeyFound = true;
-                            string apiKey = authorizationHeader.Substring(headerKey.Length).Trim();
-                            if (!string.IsNullOrEmpty(apiKey))
+                            if (authorizationHeader.StartsWith(headerKey, StringComparison.OrdinalIgnoreCase))
                             {
-                                var context = new ApiKeyValidateIdentityContext(this.Context, this.Options, apiKey);
-
-                                await this.Options.Provider.ValidateIdentity(context);
-
-                                if (context.IsValidated)
+                                headerKeyFound = true;
+                                string apiKey = authorizationHeader.Substring(headerKey.Length).Trim();
+                                if (!string.IsNullOrEmpty(apiKey))
                                 {
-                                    var claims =
-                                        await this.Options.Provider.GenerateClaims(
-                                            new ApiKeyGenerateClaimsContext(this.Context, this.Options, apiKey));
+                                    var context = new ApiKeyValidateIdentityContext(this.Context, this.Options, apiKey);
 
-                                    var identity = new ClaimsIdentity(claims, this.Options.AuthenticationType);
+                                    await this.Options.Provider.ValidateIdentity(context);
 
-                                    return new AuthenticationTicket(identity, new AuthenticationProperties()
+                                    if (context.IsValidated)
                                     {
-                                        IssuedUtc = DateTime.UtcNow
-                                    });
+                                        var claims =
+                                            await this.Options.Provider.GenerateClaims(
+                                                new ApiKeyGenerateClaimsContext(this.Context, this.Options, apiKey));
+
+                                        var identity = new ClaimsIdentity(claims, this.Options.AuthenticationType);
+
+                                        return new AuthenticationTicket(identity, new AuthenticationProperties()
+                                        {
+                                            IssuedUtc = DateTime.UtcNow
+                                        });
+                                    }
+                                }
+                                else
+                                {
+                                    throw new ArgumentNullException(nameof(Options.HeaderKey), "ApiKey not found");
                                 }
                             }
-                            else
-                            {
-                                throw new ArgumentNullException(nameof(Options.HeaderKey),"ApiKey not found");
-                            }
+                        }
+                        if (!headerKeyFound)
+                        {
+                            throw new InvalidCredentialException("Header Key Not Supported");
                         }
                     }
-                    if (!headerKeyFound)
+                    else
                     {
-                        throw new InvalidCredentialException("Header Key Not Supported");
+                        throw new ArgumentNullException(nameof(Options.HeaderKey), "No Header Key( eg: Apikey) Found.");
                     }
                 }
                 else
                 {
-                    throw new ArgumentNullException(nameof(Options.HeaderKey), "No Header Key( eg: Apikey) Found.");
+                    throw new ArgumentNullException(nameof(Options.Header), "Authorization Header is Empty.");
                 }
             }
-            else
-            {
-                throw new ArgumentNullException(nameof(authorizationHeader), "Authorization Header not found.");
-            }
-
             return null;
         }
     }

--- a/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationOptions.cs
@@ -35,6 +35,16 @@
         /// </para>
         /// <para>Authorization: ApiKey 4fb4e33c83e5d026e8745102b72f10590f48e94af107db15074c799589a4753d</para>
         /// </summary>
-        public string[] HeaderKey { get; set; } = {"ApiKey",""};
+        public string HeaderKey { get; set; } ="ApiKey";
+
+        /// <summary>
+        /// The array of supported keys for the key/value pair that represents the authentication type and its data.
+        /// Defaults to null. If value is set, this is used instead of HeaderKey
+        /// <para>
+        /// An example header using the <see cref="ApiKeyAuthenticationOptions"/> defaults would be:
+        /// </para>
+        /// <para>Authorization: ApiKey 4fb4e33c83e5d026e8745102b72f10590f48e94af107db15074c799589a4753d</para>
+        /// </summary>
+        public string[] HeaderKeyArray { get; set; } = null;
     }
 }

--- a/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.ApiKey/ApiKeyAuthenticationOptions.cs
@@ -35,6 +35,6 @@
         /// </para>
         /// <para>Authorization: ApiKey 4fb4e33c83e5d026e8745102b72f10590f48e94af107db15074c799589a4753d</para>
         /// </summary>
-        public string HeaderKey { get; set; } = "ApiKey";
+        public string[] HeaderKey { get; set; } = {"ApiKey",""};
     }
 }

--- a/src/Microsoft.Owin.Security.ApiKey/Microsoft.Owin.Security.ApiKey.nuspec
+++ b/src/Microsoft.Owin.Security.ApiKey/Microsoft.Owin.Security.ApiKey.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Owin.Security.ApiKey</id>
-    <version>1.0.2</version>
+    <version>1.0.6</version>
     <title>Microsoft.Owin.Security.ApiKey</title>
-    <authors>James Harling</authors>
-    <owners>James Harling</owners>
+    <authors>James Harling, Nithin James</authors>
+    <owners>James Harling, Nithin James</owners>
     <licenseUrl>https://github.com/jamesharling/Microsoft.Owin.Security.ApiKey/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectUrl>https://github.com/jamesharling/Microsoft.Owin.Security.ApiKey</projectUrl>
+    <projectUrl>https://github.com/hybridtechie/Microsoft.Owin.Security.ApiKey</projectUrl>
     <description>Middleware for your Owin pipeline that allows an application to perform authentication of requests via an API key in the Authorization header.</description>
     <summary>Owin middleware that enables an application to authenticate with API keys.</summary>
     <copyright>Copyright © James Harling</copyright>


### PR DESCRIPTION
**Add HeaderKey Array.**
This allows developers to support ApiKeys of the format "Apikey 123" and "1234".
This is useful when creating custom connectors for Microsoft flow or Zapier.

**Meaningful Exceptions on Errors**
Developers can catch the exception in a custom ExceptionHandlerMiddleware and provide meaning feedback to users. Currently 401 response with '"Message": "Authorization has been denied for this request."' is provided for an invalid request which doesn't give enough insight to the issue.

**Add Unit Tests for the changes**
**Existing users get errors instead of 401 response**